### PR TITLE
Add GitHub Workflow for Docker

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,45 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "30 12 * * 0" # Run once every Sunday
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ secrets.DOCKER_USERNAME }}/ultraviolet-node
+          tags: |
+            type=raw,value={{date 'YYYYMMDD'}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build & push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/ultraviolet-node:latest,${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
-Builds amd64/arm64 images
-Uploads those images to docker hub with latest and date tags
-Automatically runs once a week
-Credentials are stored in GitHub secrets

Apologies if this is a bad time. Once again, there is an example here: [https://hub.docker.com/repository/docker/seven69/ultraviolet-node/tags?page=1&ordering=last_updated](https://hub.docker.com/repository/docker/seven69/ultraviolet-node/tags?page=1&ordering=last_updated) 

Thank you for creating such wonderful software! This can definitely still be cleaned up.