### PR TITLE
add fallback for hostname()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ server.on("listening", () => {
   // we just need to list a few
   console.log("Listening on:");
   console.log(`\thttp://localhost:${address.port}`);
-  console.log(`\thttp://${hostname()}:${address.port}`);
+  console.log(`\thttp://${hostname() || "127.0.0.1"}:${address.port}`);
   console.log(
     `\thttp://${address.family === "IPv6" ? `[${address.address}]` : address.address
     }:${address.port}`


### PR DESCRIPTION
i very badly fucked up my mac (not sure how xd)
for some reason it thinks the OS `hostname` is null
<img width="320" alt="Screenshot 2024-08-18 at 3 50 18 PM" src="https://github.com/user-attachments/assets/bd161125-f7f2-451f-886e-d6a36996c5d5">
anyways 127.0.0.1 is still smth that works so i'm adding fallback